### PR TITLE
Infrastructure: change path to chat-cert

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -663,3 +663,4 @@ multiline
 Flawfinder
 ratelimited
 IGroup
+tls

--- a/src/chat/include/chat-server-const.h.in
+++ b/src/chat/include/chat-server-const.h.in
@@ -12,8 +12,10 @@
 #define CHAT_IMAGE_NUMBER_OF_FOLDERS				512
 #define	CHAT_IMAGE_MAX_WIDTH					 	640
 #define	CHAT_IMAGE_MAX_HEIGHT						480
-#define CHAT_CERTIFICATE							"${CHAT_INSTALL_DIR}"s + "/cert/chat.crt"
-#define CHAT_PRIVATE_KEY							"${CHAT_INSTALL_DIR}"s + "/private/chat.key"
+// #define CHAT_CERTIFICATE							"${CHAT_INSTALL_DIR}"s + "/cert/chat.crt"
+// #define CHAT_PRIVATE_KEY							"${CHAT_INSTALL_DIR}"s + "/private/chat.key"
+#define CHAT_CERTIFICATE							"${CHAT_INSTALL_DIR}"s + "/cert-https/tls.crt"
+#define CHAT_PRIVATE_KEY							"${CHAT_INSTALL_DIR}"s + "/cert-https/tls.key"
 
 #define	CHAT_IMAGE_DIRECTORY						string(IMAGE_DIRECTORY) + string("chat")
 #define	CHAT_IMAGE_NUMBER_OF_FOLDERS				512


### PR DESCRIPTION
Re-use LetsEncrypt certificate in chat service